### PR TITLE
Make the .json extension implied in the cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [21] Fixed how flow queues up child requests
 - [2] Added data type and expected values to schema docs
 - [10] You can specify which environment parameters are required, and provide default values for both required and optional parameters
+- [13] When specifying a request, flow, environment the .json extension is implied and will be added if not found
 
 
 ## 0.1.1

--- a/lib/files.js
+++ b/lib/files.js
@@ -14,7 +14,10 @@ function findFile(workingFolder, fileName, kind, project) {
     return fileName
   } else {
     const projectPath = project != null ? '/' + project : ''
-    const path = workingFolder + projectPath + '/' + kind +'/' + fileName
+    let path = workingFolder + projectPath + '/' + kind +'/' + fileName
+    if (!path.endsWith('.json')) {
+      path = path + '.json'
+    }
     if (fs.existsSync(path) == true) {
       return path
     }


### PR DESCRIPTION
Now you can just specify the request name (and flow or environment) and the .json will be added automatically:

```
lynn-cli> request contents
```

same as:
```
lynn-cli> request contents.json
```