### PR TITLE
Fixed crash when requests folder not found

### DIFF
--- a/bin/lynn-cli.js
+++ b/bin/lynn-cli.js
@@ -30,8 +30,13 @@ let lastFlow = {}
 let lastResult = {}
 const requests = operation.gatherOperations(conf.workingFolder, currentProject)
 const projectInfo = files.projectFileContents(conf.workingFolder, currentProject)
-console.log(chalk.yellow(projectInfo.title))
-console.log(chalk.yellow(projectInfo.description))
+if (projectInfo != null && projectInfo.title != null) {
+  console.log(chalk.yellow(projectInfo.title))
+}
+
+if (projectInfo != null && projectInfo.description != null) {
+  console.log(chalk.yellow(projectInfo.description))
+}
 
 if (conf.interactive) {
   vorpal
@@ -155,10 +160,12 @@ if (conf.interactive) {
   vorpal
       .command('generate', 'Generate the docs for this project')
       .action(function(args, callback) {
-        generate.generateDocs(conf.workingFolder, currentProject, function() {
-          vorpal.log(vorpal.chalk.yellow('Docs generated...'))
-          callback()
-        })
+        vorpal.log(vorpal.chalk.yellow('This ride is undergoing renovation, please come back once the work is completed!'))
+        callback()
+        // generate.generateDocs(conf.workingFolder, currentProject, function() {
+        //   vorpal.log(vorpal.chalk.yellow('Docs generated...'))
+        //   callback()
+        // })
       })
 
   vorpal
@@ -182,6 +189,8 @@ if (conf.interactive) {
       .command('matrix <request> <xaxis> <yaxis>',
           'Execute a series of requests with a combination of environment files')
       .action(function(args, callback) {
+        vorpal.log(vorpal.chalk.yellow('Sorry the Matrix is currently offline. Are you The One?'))
+
         // TODO: Convert over to using the operation api and figure out how to handle iterations
         // const xaxis = args.xaxis.split(',')
         // const yaxis = args.yaxis.split(',')

--- a/lib/files.js
+++ b/lib/files.js
@@ -52,6 +52,10 @@ function listFiles(workingFolder, kind, project, subfolder) {
     path = path + '/' + subfolder
   }
 
+  if (!fs.existsSync(path)) {
+    return []
+  }
+
   let files = fs.readdirSync(path).filter((a) => a.endsWith('.json') || a.endsWith('.yml') || a.endsWith('.yaml')).map((a) => subfolder ? subfolder + '/' + a: a)
   const folders = fs.readdirSync(path).filter(function(file) {
     return fs.statSync(path+'/'+file).isDirectory()


### PR DESCRIPTION
Fixes #38 

Bug introduced by a large refactor going to the OpenApi spec for all requests. Oops!

Also fixed a few initial launch / WIP things.